### PR TITLE
utf-8 decoding changes

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/ByteOptimizedUTF8Encoding.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2003, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+/**
+ * An {@link Encoding} for utf-8 which is optimized for {@code String}
+ * implementation starting with java 9 which is backed by {@code byte[]}.
+ *
+ * @author Brett Okken
+ */
+final class ByteOptimizedUTF8Encoding extends OptimizedUTF8Encoder {
+
+  private static final Charset ASCII_CHARSET = Charset.forName("ascii");
+  private static final Charset UTF_8_CHARSET = Charset.forName("UTF-8");
+
+  private static final int MAX_OPTIMIZED_LENGTH = 512 * 1024;
+
+  /**
+   * Constructs new instance.
+   */
+  ByteOptimizedUTF8Encoding() {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String decode(byte[] encodedString, int offset, int length) throws IOException {
+
+    if (length >= MAX_OPTIMIZED_LENGTH) {
+      return new String(encodedString, offset, length, UTF_8_CHARSET);
+    }
+
+    for (int i = offset, j = offset + length; i < j; ++i) {
+      // bytes are signed values. all ascii values are positive
+      if (encodedString[i] < 0) {
+        return slowDecode(encodedString, offset, length, i);
+      }
+    }
+    // we have confirmed all chars are ascii, give java that hint
+    return new String(encodedString, offset, length, ASCII_CHARSET);
+  }
+
+  /**
+   * @param encodedString
+   * @param offset
+   * @param length
+   * @param i
+   * @return
+   * @throws IOException
+   */
+  private synchronized String slowDecode(byte[] encodedString, int offset, int length, int curIdx) throws IOException {
+    char[] chars = getChars(length);
+    int out = 0;
+    for (int i = offset; i < curIdx; ++i) {
+      chars[out++] = (char) encodedString[i];
+    }
+    return decodeToChars(encodedString, curIdx, length - (curIdx - offset), chars, out);
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/core/CharOptimizedUTF8Encoding.java
+++ b/pgjdbc/src/main/java/org/postgresql/core/CharOptimizedUTF8Encoding.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2003, PostgreSQL Global Development Group
+ * See the LICENSE file in the project root for more information.
+ */
+
+package org.postgresql.core;
+
+import java.io.IOException;
+
+/**
+ * An {@link Encoding} for utf-8 which is optimized for {@code String}
+ * implementations before java 9 which are backed by {@code char[]}.
+ *
+ * @author Brett Okken
+ */
+final class CharOptimizedUTF8Encoding extends OptimizedUTF8Encoder {
+
+  /**
+   *
+   */
+  CharOptimizedUTF8Encoding() {
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public synchronized String decode(byte[] encodedString, int offset, int length) throws IOException {
+    char[] chars = getChars(length);
+    int out = 0;
+    for (int i = offset, j = offset + length; i < j; ++i) {
+      final char ch = (char) encodedString[i];
+      if ((ch & 0x80) == 0) {
+        chars[out++] = ch;
+      } else {
+        return decodeToChars(encodedString, i, j - i, chars, out);
+      }
+    }
+    return new String(chars, 0, out);
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/core/UTF8EncodingTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/core/UTF8EncodingTest.java
@@ -1,0 +1,50 @@
+package org.postgresql.core;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class UTF8EncodingTest {
+
+  @Parameterized.Parameter(0)
+  public Encoding encoding;
+
+  @Parameterized.Parameter(1)
+  public String string;
+
+  @Parameterized.Parameters(name = "string={1}, encoding={0}")
+  public static Iterable<Object[]> data() {
+    final StringBuilder reallyLongString = new StringBuilder(1024 * 1024);
+    for (int i=0; i<185000; ++i) {
+      reallyLongString.append(i);
+    }
+
+    final String[] strings = new String[] {
+        "short simple",
+        "longer but still not really all that long",
+        reallyLongString.toString(),
+        "eat \u03A3 \u03C0"
+    };
+
+    final List<Object[]> data = new ArrayList<>(strings.length * 2);
+    for (Encoding encoding : Arrays.asList(new CharOptimizedUTF8Encoding(), new ByteOptimizedUTF8Encoding())) {
+      for (String string : strings) {
+        data.add(new Object[] {encoding, string});
+      }
+    }
+    return data;
+  }
+
+  @Test
+  public void test() throws Exception {
+    final byte[] encoded = encoding.encode(string);
+    assertEquals(string, encoding.decode(encoded));
+  }
+}

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/Jdbc2TestSuite.java
@@ -11,6 +11,7 @@ import org.postgresql.core.OidToStringTest;
 import org.postgresql.core.OidValueOfTest;
 import org.postgresql.core.ParserTest;
 import org.postgresql.core.ReturningParserTest;
+import org.postgresql.core.UTF8EncodingTest;
 import org.postgresql.core.v3.V3ParameterListTests;
 import org.postgresql.jdbc.DeepBatchedInsertStatementTest;
 import org.postgresql.jdbc.PrimitiveArraySupportTest;
@@ -122,7 +123,9 @@ import org.junit.runners.Suite;
         CopyLargeFileTest.class,
         ServerErrorTest.class,
         UpsertTest.class,
-        OuterJoinSyntaxTest.class
+        OuterJoinSyntaxTest.class,
+
+        UTF8EncodingTest.class
 })
 public class Jdbc2TestSuite {
 }


### PR DESCRIPTION
Puts limits on size of char[] reusued.
Provides different implementations for java 9+ optimized for the byte[] backed String implementation.